### PR TITLE
Fix bug: ReactJS codes are disabled after deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /node_modules
 /.pnp
 .pnp.js
+.firebase
 
 # testing
 /coverage

--- a/firebase.json
+++ b/firebase.json
@@ -3,7 +3,7 @@
     "rules": "database.rules.json"
   },
   "hosting": {
-    "public": "public",
+    "public": "build",
     "ignore": [
       "firebase.json",
       "**/.*",


### PR DESCRIPTION
This problem caused by incorrect hosting directory.
Now my app can use ReactJS code after deploy :)

[![Image from Gyazo](https://i.gyazo.com/8e8654282708b594ebc0ffe511530d30.png)](https://gyazo.com/8e8654282708b594ebc0ffe511530d30)